### PR TITLE
Some changes to `prepare.sh` and `create.sh` 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,1 +1,2 @@
 If you make any changes or do anything to FemboyOS, add yourself here :3 :
+* [@Tadavomnist](https://github.com/TadavomnisT) (behrad.b)

--- a/build_env/create.sh
+++ b/build_env/create.sh
@@ -20,28 +20,28 @@ fi
 echo "Creating build env... UwU"
 cd $DIST_ROOT/build_env
 
-sudo bash -e build_scripts/binutils-pass-1.sh
-sudo bash -e build_scripts/gcc-pass-1.sh
-sudo bash -e build_scripts/linux-headers.sh
-sudo bash -e build_scripts/glibc.sh
-sudo bash -e build_scripts/libstdcpp-pass-1.sh gcc-12.2.0.tar.xz
-sudo bash -e build_scripts/m4.sh m4-1.4.19.tar.xz
-sudo bash -e build_scripts/ncurses.sh ncurses-6.3.tar.gz
-sudo bash -e build_scripts/bash.sh bash-5.1.16.tar.gz
-sudo bash -e build_scripts/coreutils.sh coreutils-9.1.tar.xz 
-sudo bash -e build_scripts/diffutils.sh diffutils-3.8.tar.xz
-sudo bash -e build_scripts/file.sh file-5.42.tar.gz
-sudo bash -e build_scripts/findutils.sh findutils-4.9.0.tar.xz
-sudo bash -e build_scripts/gawk.sh gawk-5.1.1.tar.xz
-sudo bash -e build_scripts/grep.sh grep-3.7.tar.xz
-sudo bash -e build_scripts/gzip.sh gzip-1.12.tar.xz
-sudo bash -e build_scripts/make.sh make-4.3.tar.gz
-sudo bash -e build_scripts/patch.sh patch-2.7.6.tar.xz 
-sudo bash -e build_scripts/sed.sh sed-4.8.tar.xz
-sudo bash -e build_scripts/tar.sh tar-1.34.tar.xz
-sudo bash -e build_scripts/xz.sh xz-5.2.6.tar.xz 
-sudo bash -e build_scripts/binutils-pass-2.sh binutils-2.39.tar.xz
-sudo bash -e build_scripts/gcc-pass-2.sh gcc-12.2.0.tar.xz
+bash -e build_scripts/binutils-pass-1.sh
+bash -e build_scripts/gcc-pass-1.sh
+bash -e build_scripts/linux-headers.sh
+bash -e build_scripts/glibc.sh
+bash -e build_scripts/libstdcpp-pass-1.sh gcc-12.2.0.tar.xz
+bash -e build_scripts/m4.sh m4-1.4.19.tar.xz
+bash -e build_scripts/ncurses.sh ncurses-6.3.tar.gz
+bash -e build_scripts/bash.sh bash-5.1.16.tar.gz
+bash -e build_scripts/coreutils.sh coreutils-9.1.tar.xz 
+bash -e build_scripts/diffutils.sh diffutils-3.8.tar.xz
+bash -e build_scripts/file.sh file-5.42.tar.gz
+bash -e build_scripts/findutils.sh findutils-4.9.0.tar.xz
+bash -e build_scripts/gawk.sh gawk-5.1.1.tar.xz
+bash -e build_scripts/grep.sh grep-3.7.tar.xz
+bash -e build_scripts/gzip.sh gzip-1.12.tar.xz
+bash -e build_scripts/make.sh make-4.3.tar.gz
+bash -e build_scripts/patch.sh patch-2.7.6.tar.xz 
+bash -e build_scripts/sed.sh sed-4.8.tar.xz
+bash -e build_scripts/tar.sh tar-1.34.tar.xz
+bash -e build_scripts/xz.sh xz-5.2.6.tar.xz 
+bash -e build_scripts/binutils-pass-2.sh binutils-2.39.tar.xz
+bash -e build_scripts/gcc-pass-2.sh gcc-12.2.0.tar.xz
 
 sudo cp build_root/usr/lib//ld-linux-x86-64.so.2 build_root/lib/
 sudo ln -f build_root/usr/bin/bash build_root/bin/sh

--- a/build_env/create.sh
+++ b/build_env/create.sh
@@ -1,5 +1,14 @@
 set -e
 
+if [ -z ${LFS+x} ]; then
+echo "[*]\$LFS is not defined or NULL";
+exit -1
+fi
+if [ -z ${DIST_ROOT+x} ]; then
+echo "[*]\$DIST_ROOT is not defined or NULL";
+exit -1
+fi
+
 echo "Dist Root: ${DIST_ROOT:?}"
 echo "LFS: ${LFS:?}"
 
@@ -11,28 +20,28 @@ fi
 echo "Creating build env... UwU"
 cd $DIST_ROOT/build_env
 
-bash -e build_scripts/binutils-pass-1.sh
-bash -e build_scripts/gcc-pass-1.sh
-bash -e build_scripts/linux-headers.sh
-bash -e build_scripts/glibc.sh
-bash -e build_scripts/libstdcpp-pass-1.sh gcc-12.2.0.tar.xz
-bash -e build_scripts/m4.sh m4-1.4.19.tar.xz
-bash -e build_scripts/ncurses.sh ncurses-6.3.tar.gz
-bash -e build_scripts/bash.sh bash-5.1.16.tar.gz
-bash -e build_scripts/coreutils.sh coreutils-9.1.tar.xz 
-bash -e build_scripts/diffutils.sh diffutils-3.8.tar.xz
-bash -e build_scripts/file.sh file-5.42.tar.gz
-bash -e build_scripts/findutils.sh findutils-4.9.0.tar.xz
-bash -e build_scripts/gawk.sh gawk-5.1.1.tar.xz
-bash -e build_scripts/grep.sh grep-3.7.tar.xz
-bash -e build_scripts/gzip.sh gzip-1.12.tar.xz
-bash -e build_scripts/make.sh make-4.3.tar.gz
-bash -e build_scripts/patch.sh patch-2.7.6.tar.xz 
-bash -e build_scripts/sed.sh sed-4.8.tar.xz
-bash -e build_scripts/tar.sh tar-1.34.tar.xz
-bash -e build_scripts/xz.sh xz-5.2.6.tar.xz 
-bash -e build_scripts/binutils-pass-2.sh binutils-2.39.tar.xz
-bash -e build_scripts/gcc-pass-2.sh gcc-12.2.0.tar.xz
+sudo bash -e build_scripts/binutils-pass-1.sh
+sudo bash -e build_scripts/gcc-pass-1.sh
+sudo bash -e build_scripts/linux-headers.sh
+sudo bash -e build_scripts/glibc.sh
+sudo bash -e build_scripts/libstdcpp-pass-1.sh gcc-12.2.0.tar.xz
+sudo bash -e build_scripts/m4.sh m4-1.4.19.tar.xz
+sudo bash -e build_scripts/ncurses.sh ncurses-6.3.tar.gz
+sudo bash -e build_scripts/bash.sh bash-5.1.16.tar.gz
+sudo bash -e build_scripts/coreutils.sh coreutils-9.1.tar.xz 
+sudo bash -e build_scripts/diffutils.sh diffutils-3.8.tar.xz
+sudo bash -e build_scripts/file.sh file-5.42.tar.gz
+sudo bash -e build_scripts/findutils.sh findutils-4.9.0.tar.xz
+sudo bash -e build_scripts/gawk.sh gawk-5.1.1.tar.xz
+sudo bash -e build_scripts/grep.sh grep-3.7.tar.xz
+sudo bash -e build_scripts/gzip.sh gzip-1.12.tar.xz
+sudo bash -e build_scripts/make.sh make-4.3.tar.gz
+sudo bash -e build_scripts/patch.sh patch-2.7.6.tar.xz 
+sudo bash -e build_scripts/sed.sh sed-4.8.tar.xz
+sudo bash -e build_scripts/tar.sh tar-1.34.tar.xz
+sudo bash -e build_scripts/xz.sh xz-5.2.6.tar.xz 
+sudo bash -e build_scripts/binutils-pass-2.sh binutils-2.39.tar.xz
+sudo bash -e build_scripts/gcc-pass-2.sh gcc-12.2.0.tar.xz
 
 sudo cp build_root/usr/lib//ld-linux-x86-64.so.2 build_root/lib/
 sudo ln -f build_root/usr/bin/bash build_root/bin/sh

--- a/build_env/prepare.sh
+++ b/build_env/prepare.sh
@@ -1,5 +1,15 @@
-echo "Testing $LFS and $DIST_ROOT variables, if you don't have them set,"
-echo "LFS is: '(path to FemboyOS)/build_env/build_root' (eg. /basia/FemboyOS//build_env/build_root/), and $DIST_ROOT is (path to FemboyOS) (eg. /basia/FemboyOS/)"
+echo "Testing \$LFS and \$DIST_ROOT variables, if you don't have them set,"
+echo "\n\$LFS is: '(path to FemboyOS)/build_env/build_root' (eg. /basia/FemboyOS/build_env/build_root/), and \$DIST_ROOT is (path to FemboyOS) (eg. /basia/FemboyOS/)"
+
+if [ -z ${LFS+x} ]; then
+echo "[*]\$LFS is not defined or NULL";
+exit -1
+fi
+if [ -z ${DIST_ROOT+x} ]; then
+echo "[*]\$DIST_ROOT is not defined or NULL";
+exit -1
+fi
+
 
 echo "Dist Root: ${DIST_ROOT:?}"
 echo "LFS: ${LFS:?}"
@@ -20,14 +30,32 @@ do
     fi
 
 done; 
-mkdir -pv $LFS/{bin,etc,lib,sbin,usr,var,lib64,tools}
+
+
+mkdir -pv $LFS/bin
+mkdir -pv $LFS/etc
+mkdir -pv $LFS/lib
+mkdir -pv $LFS/sbin
+mkdir -pv $LFS/usr
+mkdir -pv $LFS/var
+mkdir -pv $LFS/lib64
+mkdir -pv $LFS/tools
+
 
 if ! test $(id -u distbuild) ; then
 
-groupadd distbuild
-useradd -s /bin/bash -g distbuild -m -k /dev/null distbuild
-passwd distbuild
-chown -v distbuild $LFS/{usr,lib,var,etc,bin,sbin,tools,lib64,sources}
+sudo groupadd distbuild
+sudo useradd -s /bin/bash -g distbuild -m -k /dev/null distbuild
+sudo passwd distbuild
+sudo chown -v distbuild $LFS/usr
+sudo chown -v distbuild $LFS/lib
+sudo chown -v distbuild $LFS/var
+sudo chown -v distbuild $LFS/etc
+sudo chown -v distbuild $LFS/bin
+sudo chown -v distbuild $LFS/sbin
+sudo chown -v distbuild $LFS/tools
+sudo chown -v distbuild $LFS/lib64
+sudo chown -v distbuild $LFS/sources
 
 dbhome=$(eval echo "~distbuild")
 


### PR DESCRIPTION
There were some... problems with `prepare.sh` and other scripts in my scenario ... That's why I made some changes , here is an explanation of changes :

`prepare.sh`:

```diff
- echo "Testing $LFS and $DIST_ROOT variables, if you don't have them set,"
- echo "LFS is: '(path to FemboyOS)/build_env/build_root' (eg. /basia/FemboyOS//build_env/build_root/), and $DIST_ROOT is (path to FemboyOS) (eg. /basia/FemboyOS/)"
+ echo "Testing \$LFS and \$DIST_ROOT variables, if you don't have them set,"
+ echo "\n\$LFS is: '(path to FemboyOS)/build_env/build_root' (eg. /basia/FemboyOS/build_env/build_root/), and \$DIST_ROOT is (path to FemboyOS) (eg. /basia/FemboyOS/)"

+ if [ -z ${LFS+x} ]; then
+ echo "[*]\$LFS is not defined or NULL";
+ exit -1
+ fi
+ if [ -z ${DIST_ROOT+x} ]; then
+ echo "[*]\$DIST_ROOT is not defined or NULL";
+ exit -1
+ fi
```
The $DollarSign is special char, so it needs to be escaped in strings, otherwise it represents a variable.
and I added some extra var checkers if you don't mind *-*   

```diff
- mkdir -pv $LFS/{bin,etc,lib,sbin,usr,var,lib64,tools}

+ mkdir -pv $LFS/bin
+ mkdir -pv $LFS/etc
+ mkdir -pv $LFS/lib
+ mkdir -pv $LFS/sbin
+ mkdir -pv $LFS/usr
+ mkdir -pv $LFS/var
+ mkdir -pv $LFS/lib64
+ mkdir -pv $LFS/tools
```
From what I found out, The bash encapsulates parameters as strings , so if you execute:
```shell
mkdir -pv $LFS/{bin,etc,lib,sbin,usr,var,lib64,tools}
```
as a single command in terminal , It works perfectly alright , But in bash It creates a single directory named `{bin,etc,lib,sbin,usr,var,lib64,tools}` which is insane! So there are several ways to prevent that, but making them one after another is the simplest way.

```diff
- groupadd distbuild
- useradd -s /bin/bash -g distbuild -m -k /dev/null distbuild
- passwd distbuild
- chown -v distbuild $LFS/{usr,lib,var,etc,bin,sbin,tools,lib64,sources}
+ sudo groupadd distbuild
+ sudo useradd -s /bin/bash -g distbuild -m -k /dev/null distbuild
+ sudo passwd distbuild
+ sudo chown -v distbuild $LFS/usr
+ sudo chown -v distbuild $LFS/lib
+ sudo chown -v distbuild $LFS/var
+ sudo chown -v distbuild $LFS/etc
+ sudo chown -v distbuild $LFS/bin
+ sudo chown -v distbuild $LFS/sbin
+ sudo chown -v distbuild $LFS/tools
+ sudo chown -v distbuild $LFS/lib64
+ sudo chown -v distbuild $LFS/sources
```
As far as I know, calling commands like `groupadd` or `useradd` or `passwd` or even `chown`  requires root access,... well tbh It does in my distro, dunno about others! 
So, I think it's safe to add `sudo`  ...
and the same thing as `mkdir` goes for `chown` when dealing with several directories... So I put it in several commands. 
_____________________

Did some changes to `create.sh`  too :
```diff
+ if [ -z ${LFS+x} ]; then
+ echo "[*]\$LFS is not defined or NULL";
+ exit -1
+ fi
+ if [ -z ${DIST_ROOT+x} ]; then
+ echo "[*]\$DIST_ROOT is not defined or NULL";
+ exit -1
+ fi
```
Just a simple checker, not a big deal...
